### PR TITLE
fix (parseEntryUser): support extended user object for failed authentications

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -173,7 +173,9 @@ $this->module('logger')->extend([
     return 'info';
   },
 
-  'parseEntryUser' => function($username) {
+  'parseEntryUser' => function($userEntry) {
+    $username = $userEntry['user'] ?? $userEntry;
+
     $user = [
       'name' => $username,
       'id' => '',

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -174,15 +174,22 @@ $this->module('logger')->extend([
   },
 
   'parseEntryUser' => function($userEntry) {
-    $username = $userEntry['user'] ?? $userEntry;
+    if(isset($userEntry['email'])){
+      $criteria = ['email' => $userEntry['email']];
+    }else if(isset($userEntry['user'])){
+      $criteria = ['user' => $userEntry['user']];
+    }else if(is_string($userEntry)){
+      $criteria = ['user' => $userEntry];
+    }else{
+      throw new \ErrorException('Bad parameter for $userEntry; ');
+    }
 
     $user = [
-      'name' => $username,
-      'id' => '',
+      'name' => $criteria['email'] ?? $criteria['user'],
+      'id' => ''
     ];
-    $account = $this->app->storage->findOne('cockpit/accounts', [
-      'user' => $username,
-    ]);
+
+    $account = $this->app->storage->findOne('cockpit/accounts', $criteria);
     if ($account && isset($account['_id'])) {
       $user['id'] = $account['_id'];
     }


### PR DESCRIPTION
## The bug
During testing out the latest version of the logger in regards to the logging of login, logout, failed login events I got the following error on loading the "Recent logs" view:

`Condition not valid ... Use  user  for custom operations` error in `MongoLite\Database.php:466` 

The error was triggered during `getLogContents:209` where `parseEntryUser` is called.

`parseEntryUser` expects a string as parameter, the username. 
Successful logins save only the username in the `logEntry[user]` field.

**But the `cockpit.authentication.failed` event does not consistently return a username but sometimes the username and sometimes the whole `$data` array with  `[user => 'x', password => 'y']`.**

And when `$data` was then sent to the DB as a criteria `['user' => ['user' => 'admin', 'password' => 'wrong']]` the query failed because "`user` is not a valid function".

### The additional edge-case bug
In addition the `$data` might also contain not the `user` key but the `email` key.

## The fix
`parseEntryUser` was now extended, to handle 
 - an array with a key `user` or `email` 
  - or a string with the actual username